### PR TITLE
Simplify kmg.domain/recommendation-ids

### DIFF
--- a/src/kmg/domain.clj
+++ b/src/kmg/domain.clj
@@ -56,7 +56,7 @@
 (defn recommendation-ids [db user]
   (let [recs (recommendations-for-user db user)
         completed (set (recommendations-completed-by-user db user))]
-    (filter #(not (contains? completed %)) recs)))
+    (keep completed recs)))
 
 ;; (recommendation-ids (db) "user1")
 ;; (recommendation-ids (db) "user2")


### PR DESCRIPTION
As we all know, parentheses are evil. Let's get rid of some of them and make the code more readable!
