### PR TITLE
One more attempt to simplify recommendation-ids

### DIFF
--- a/src/kmg/domain.clj
+++ b/src/kmg/domain.clj
@@ -51,7 +51,7 @@
 (defn recommendation-ids [db user]
   (let [recs (recommendations-for-user db user)
         completed (set (recommendations-completed-by-user db user))]
-    (filter #(not (contains? completed %)) recs)))
+    (remove completed recs)))
 
 ;; (recommendation-ids (db) "user1")
 ;; (recommendation-ids (db) "user2")


### PR DESCRIPTION
It works as intended this time:

``` clojure
(let [recs [1 2 3 4 5] completed (set [2 4 6 8])] (filter #(not (contains? completed %)) recs))
;; => (1 3 5)
(let [recs [1 2 3 4 5] completed (set [2 4 6 8])] (remove completed recs))
;; => (1 3 5)
```
