### PR TITLE
Simplify kmg.datomic-helpers/prepare-entity

### DIFF
--- a/src/kmg/datomic_helpers.clj
+++ b/src/kmg/datomic_helpers.clj
@@ -27,7 +27,7 @@
 (defn prepare-entity [data]
   (if (contains? data :db/id)
     data
-    (merge data {:db/id (d/tempid :db.part/user)})))
+    (assoc data :db/id (d/tempid :db.part/user))))
 
 (defn prepare-entities [data]
   (map prepare-entity data))


### PR DESCRIPTION
Brackets are evil, so let's remove a pair. Curly ones are especially ugly. The best list is a lisp without brackets!
